### PR TITLE
Add board validation

### DIFF
--- a/src/crossword_generator.py
+++ b/src/crossword_generator.py
@@ -137,7 +137,7 @@ def board_input(text: str) -> tuple[list, set]:
 
 def input_to_board(text: str) -> List[List[str]]:
     board = []
-    # TODO throw error is board isn't of some size
+    row_length = None
 
     for letters in text.split("\n"):
         row = []
@@ -147,7 +147,18 @@ def input_to_board(text: str) -> List[List[str]]:
                     "Invalid input type, use only 'x', 'o', and newlines ('\\n')"
                 )
             row.append(char.lower())
+
+        if row_length is None:
+            row_length = len(row)
+            if row_length == 0:
+                raise ValueError("No columns provided")
+        elif len(row) != row_length:
+            raise ValueError("All rows must have the same length")
+
         board.append(row)
+
+    if not board:
+        raise ValueError("No rows provided")
 
     return board
 

--- a/tests/test_crossword_generator.py
+++ b/tests/test_crossword_generator.py
@@ -1,5 +1,5 @@
 import pprint
-# import pytest
+import pytest
 from crossword_generator import (
     TrieNode,
     create_crossword,
@@ -46,6 +46,12 @@ def test_input_to_board_x():
 xxX
 Xxx"""
     assert input_to_board(text) == [["x", "x", "x"], ["x", "x", "x"], ["x", "x", "x"]]
+
+
+def test_input_to_board_invalid():
+    text = "xx\nxxx"
+    with pytest.raises(ValueError):
+        input_to_board(text)
 
 
 def test_load_and_build_tries_of_diff_lengths():


### PR DESCRIPTION
## Summary
- validate board size when converting input
- test malformed input to `input_to_board`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aca4e8858832ebdb559f40473ab12